### PR TITLE
Added message and additional dirty plugin data for ZL-MP5 Pack.esp

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4672,10 +4672,19 @@ plugins:
         nav: 0
   - name: 'ZL-MP5 Pack.esp'
     url: 'http://www.nexusmods.com/fallout3/mods/5431'
-    tag:
+    msg:
+  - type: say
+    content: "'ZL-MP5 Pack.esp from KDSZealotleeMP5withIronsights is preferred when using RH_Ironsights'"
+    condition: "active("RH_IRONSIGHTS") and (checksum("ZL-MP5 Pack.esp", 022E817B) or checksum("ZL-MP5 Pack.esp",022E817B))"
+	tag:
       - Stats
     dirty:
       - crc: 0xB7146642
+        util: *dirtyUtil # FO3Edit 3.0.32
+        itm: 6
+        udr: 0
+        nav: 0
+	 - crc: 0xcd453ee7
         util: *dirtyUtil # FO3Edit 3.0.32
         itm: 6
         udr: 0

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4674,9 +4674,9 @@ plugins:
     url: 'http://www.nexusmods.com/fallout3/mods/5431'
     msg:
   - type: say
-    content: "'ZL-MP5 Pack.esp from KDSZealotleeMP5withIronsights is preferred when using RH_Ironsights'"
-    condition: "active("RH_IRONSIGHTS") and (checksum("ZL-MP5 Pack.esp", 022E817B) or checksum("ZL-MP5 Pack.esp",022E817B))"
-	tag:
+      content: 'ZL-MP5 Pack.esp from KDSZealotleeMP5withIronsights is preferred when using RH_Ironsights'
+      condition: 'active('RH_IRONSIGHTS.esm') and (checksum('ZL-MP5 Pack.esp', 022E817B) or checksum('ZL-MP5 Pack.esp',022E817B))'
+    tag:
       - Stats
     dirty:
       - crc: 0xB7146642
@@ -4684,7 +4684,7 @@ plugins:
         itm: 6
         udr: 0
         nav: 0
-	 - crc: 0xcd453ee7
+      - crc: 0xcd453ee7
         util: *dirtyUtil # FO3Edit 3.0.32
         itm: 6
         udr: 0


### PR DESCRIPTION
Dirty plugin data for the version of ZL-MP5 Pack.esp in KDSZealotleeMP5withIronsights was added.
The url for this mod was not added since it doesn't look like the masterlist includes multiple urls for the same plugin.
A message was added so that if RH_Ironsights mod is used but the non-Ironsights compatible ZL-MP5 Pack plugin is present to suggest using the version of this plugin compatible with RH_Ironsights.
