### PR TITLE
Update Unofficial Fallout 3 Patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -805,6 +805,7 @@ plugins:
         name: 'Updated Unofficial Fallout 3 Patch'
     group: *fixesGroup
     after: [ 'ObjectPlacementFix.esm' ]
+    req: [ *FOSE ]
     msg:
       - <<: *obsolete
         subs: [ '[Updated Unofficial Fallout 3 Patch](https://www.nexusmods.com/fallout3/mods/19122)' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -812,6 +812,31 @@ plugins:
     clean:
       - crc: 0xF71755E7
         util: 'FO3Edit v4.0.3'
+  - name: 'UUF3P - FWE Patch.esp'
+    url: [ 'https://www.nexusmods.com/fallout3/mods/19122' ]
+    after:
+      - 'delaypl.esp'
+      - 'FO3 Wanderers Edition - Main File.esp'
+    req:
+      - 'FO3 Wanderers Edition - Main File.esp'
+    tag:
+      - Actors.ACBS
+      - Actors.AIData
+      - Actors.Stats
+      - Deflst
+      - Delev
+      - Destructible
+      - Factions
+      - Graphics
+      - Invent
+      - Names
+      - Relations
+      - Relev
+      - Scripts
+      - Stats
+    clean:
+      - crc: 0xF404243F
+        util: 'FO3Edit v4.0.2e'
 
   - name: 'StreetLights.esm'
     url: [ 'https://www.nexusmods.com/fallout3/mods/8069' ]
@@ -8801,34 +8826,6 @@ plugins:
     clean:
       - crc: 0x196F177D
         util: 'FO3Edit v4.0.2e'
-
-  ### Fallout 3 Wanderers Edition-section
-  - name: 'UUF3P - FWE Patch.esp'
-    url: [ 'https://www.nexusmods.com/fallout3/mods/19122' ]
-    after:
-      - 'delaypl.esp'
-      - 'FO3 Wanderers Edition - Main File.esp'
-    req:
-      - 'FO3 Wanderers Edition - Main File.esp'
-    tag:
-      - Actors.ACBS
-      - Actors.AIData
-      - Actors.Stats
-      - Deflst
-      - Delev
-      - Destructible
-      - Factions
-      - Graphics
-      - Invent
-      - Names
-      - Relations
-      - Relev
-      - Scripts
-      - Stats
-    clean:
-      - crc: 0xF404243F
-        util: 'FO3Edit v4.0.2e'
-
 
   ### Load Late-section
   - name: 'Merged.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -816,7 +816,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/fallout3/mods/19122' ]
     after:
       - 'delaypl.esp'
-      - 'FO3 Wanderers Edition - Main File.esp'
     req:
       - 'FO3 Wanderers Edition - Main File.esp'
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -798,6 +798,7 @@ plugins:
         util: '[FO3Edit v4.0.3](https://www.nexusmods.com/fallout3/mods/637)'
         itm: 15
 
+###### Unofficial Patches ######
   - name: 'Unofficial Fallout 3 Patch.esm'
     url:
       - link: 'https://www.nexusmods.com/fallout3/mods/19122/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -856,10 +856,6 @@ plugins:
     clean:
       - crc: 0xF71755E7
         util: 'FO3Edit v4.0.3'
-  - name: 'UUF3P - FWE Patch.esp'
-    url: [ 'https://www.nexusmods.com/fallout3/mods/19122' ]
-    after: [ 'delaypl.esp' ]
-    req: [ 'FO3 Wanderers Edition - Main File.esp' ]
 
   - name: 'StreetLights.esm'
     url: [ 'https://www.nexusmods.com/fallout3/mods/8069' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -856,6 +856,14 @@ plugins:
     clean:
       - crc: 0xF71755E7
         util: 'FO3Edit v4.0.3'
+  - name: 'Goodies.esp'
+    url: [ 'https://www.nexusmods.com/fallout3/mods/19122/' ]
+    tag:
+      - Delev
+      - Invent.Add
+      - Invent.Remove
+      - Names
+      - Relev
 
   - name: 'StreetLights.esm'
     url: [ 'https://www.nexusmods.com/fallout3/mods/8069' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -809,7 +809,7 @@ plugins:
     msg:
       - <<: *obsolete
         subs: [ '[Updated Unofficial Fallout 3 Patch](https://www.nexusmods.com/fallout3/mods/19122)' ]
-        condition: 'version("Unofficial Fallout 3 Patch.esm", "1.8", <)'
+        condition: 'version("Unofficial Fallout 3 Patch.esm", "3.0", <)'
     tag:
       - C.Music
       - Deflst

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -814,10 +814,8 @@ plugins:
         util: 'FO3Edit v4.0.3'
   - name: 'UUF3P - FWE Patch.esp'
     url: [ 'https://www.nexusmods.com/fallout3/mods/19122' ]
-    after:
-      - 'delaypl.esp'
-    req:
-      - 'FO3 Wanderers Edition - Main File.esp'
+    after: [ 'delaypl.esp' ]
+    req: [ 'FO3 Wanderers Edition - Main File.esp' ]
     clean:
       - crc: 0xF404243F
         util: 'FO3Edit v4.0.2e'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -828,6 +828,34 @@ plugins:
         crc: 0x7AAABC4D
         util: '[FO3Edit v4.0.2e](https://www.nexusmods.com/fallout3/mods/637)'
         nav: 2
+  - name: 'Unofficial Fallout 3 Patch - Operation Anchorage.esp'
+    group: *fixesGroup
+    tag:
+      - Deflst
+      - Names
+  - name: 'Unofficial Fallout 3 Patch - The Pitt.esp'
+    group: *fixesGroup
+    tag:
+      - Deflst
+      - Names
+  - name: 'Unofficial Fallout 3 Patch - Broken Steel.esp'
+    group: *fixesGroup
+    tag:
+      - Deflst
+      - Names
+      - NoMerge
+  - name: 'Unofficial Fallout 3 Patch - Point Lookout.esp'
+    group: *fixesGroup
+    tag:
+      - Deflst
+      - Invent
+      - Names
+      - Stats
+  - name: 'Unofficial Fallout 3 Patch - Mothership Zeta.esp'
+    group: *fixesGroup
+    tag:
+      - Deflst
+      - Names
 
   - name: 'StreetLights.esm'
     url: [ 'https://www.nexusmods.com/fallout3/mods/8069' ]
@@ -1858,34 +1886,6 @@ plugins:
     tag:
       - Names
       - NoMerge
-  - name: 'Unofficial Fallout 3 Patch - Operation Anchorage.esp'
-    group: *fixesGroup
-    tag:
-      - Deflst
-      - Names
-  - name: 'Unofficial Fallout 3 Patch - The Pitt.esp'
-    group: *fixesGroup
-    tag:
-      - Deflst
-      - Names
-  - name: 'Unofficial Fallout 3 Patch - Broken Steel.esp'
-    group: *fixesGroup
-    tag:
-      - Deflst
-      - Names
-      - NoMerge
-  - name: 'Unofficial Fallout 3 Patch - Point Lookout.esp'
-    group: *fixesGroup
-    tag:
-      - Deflst
-      - Invent
-      - Names
-      - Stats
-  - name: 'Unofficial Fallout 3 Patch - Mothership Zeta.esp'
-    group: *fixesGroup
-    tag:
-      - Deflst
-      - Names
   - name: 'CinderBlockRockFix.esp'
     inc:
       - 'CinderblockRockFix2.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -809,6 +809,50 @@ plugins:
       - <<: *obsolete
         subs: [ '[Updated Unofficial Fallout 3 Patch](https://www.nexusmods.com/fallout3/mods/19122)' ]
         condition: 'version("Unofficial Fallout 3 Patch.esm", "3.0", <)'
+    tag:
+      - Actors.ACBS
+      - Actors.AIData
+      - Actors.AIPackages
+      - Actors.Anims
+      - Actors.CombatStyle
+      - Actors.DeathItem
+      - Actors.RecordFlags
+      - Actors.Skeleton
+      - Actors.Spells
+      - Actors.Stats
+      - C.Acoustic
+      - C.Encounter
+      - C.ImageSpace
+      - C.Light
+      - C.MiscFlags
+      - C.Music
+      - C.Name
+      - C.Owner
+      - C.Regions
+      - C.Water
+      - Creatures.Blood
+      - Creatures.Type
+      - Deflst
+      - Delev
+      - Factions
+      - Graphics
+      - Invent.Add
+      - Invent.Change
+      - Invent.Remove
+      - Names
+      - NPC.Class
+      - NPC.Eyes
+      - NPC.FaceGen
+      - NPC.Hair
+      - NPC.Race
+      - Relations.Add
+      - Relations.Change
+      - Relations.Remove
+      - Relev
+      - Scripts
+      - Sound
+      - Stats
+      - Text
     clean:
       - crc: 0xF71755E7
         util: 'FO3Edit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -836,31 +836,27 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/fallout3/mods/3808/'
         name: 'Unofficial Fallout 3 Patch'
-  - name: 'Unofficial Fallout 3 Patch - Operation Anchorage.esp'
     group: *fixesGroup
+  - name: 'Unofficial Fallout 3 Patch - Operation Anchorage.esp'
     tag:
       - Deflst
       - Names
   - name: 'Unofficial Fallout 3 Patch - The Pitt.esp'
-    group: *fixesGroup
     tag:
       - Deflst
       - Names
   - name: 'Unofficial Fallout 3 Patch - Broken Steel.esp'
-    group: *fixesGroup
     tag:
       - Deflst
       - Names
       - NoMerge
   - name: 'Unofficial Fallout 3 Patch - Point Lookout.esp'
-    group: *fixesGroup
     tag:
       - Deflst
       - Invent
       - Names
       - Stats
   - name: 'Unofficial Fallout 3 Patch - Mothership Zeta.esp'
-    group: *fixesGroup
     tag:
       - Deflst
       - Names

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -799,7 +799,11 @@ plugins:
         itm: 15
 
   - name: 'Unofficial Fallout 3 Patch.esm'
-    url: [ 'https://www.nexusmods.com/fallout3/mods/19122' ]
+    url:
+      - link: 'https://www.nexusmods.com/fallout3/mods/3808/'
+        name: 'Unofficial Fallout 3 Patch'
+      - link: 'https://www.nexusmods.com/fallout3/mods/19122/'
+        name: 'Updated Unofficial Fallout 3 Patch'
     group: *fixesGroup
     after:
       - 'ThePitt.esm'
@@ -828,6 +832,10 @@ plugins:
         crc: 0x7AAABC4D
         util: '[FO3Edit v4.0.2e](https://www.nexusmods.com/fallout3/mods/637)'
         nav: 2
+  - name: 'Unofficial Fallout 3 Patch - (Operation Anchorage|The Pitt|Broken Steel|Point Lookout|Mothership Zeta)\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout3/mods/3808/'
+        name: 'Unofficial Fallout 3 Patch'
   - name: 'Unofficial Fallout 3 Patch - Operation Anchorage.esp'
     group: *fixesGroup
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -805,14 +805,7 @@ plugins:
       - link: 'https://www.nexusmods.com/fallout3/mods/19122/'
         name: 'Updated Unofficial Fallout 3 Patch'
     group: *fixesGroup
-    after:
-      - 'ThePitt.esm'
-      - 'Anchorage.esm'
-      - 'StreetLights.esm'
-      - 'BrokenSteel.esm'
-      - 'PointLookout.esm'
-      - 'Zeta.esm'
-      - 'ObjectPlacementFix.esm'
+    after: [ 'ObjectPlacementFix.esm' ]
     msg:
       - <<: *obsolete
         subs: [ '[Updated Unofficial Fallout 3 Patch](https://www.nexusmods.com/fallout3/mods/19122)' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -808,16 +808,6 @@ plugins:
       - <<: *obsolete
         subs: [ '[Updated Unofficial Fallout 3 Patch](https://www.nexusmods.com/fallout3/mods/19122)' ]
         condition: 'version("Unofficial Fallout 3 Patch.esm", "3.0", <)'
-    tag:
-      - C.Music
-      - Deflst
-      - Delev
-      - Factions
-      - Invent
-      - Names
-      - Relations
-      - Relev
-      - Stats
     clean:
       - crc: 0xF71755E7
         util: 'FO3Edit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -800,8 +800,6 @@ plugins:
 
   - name: 'Unofficial Fallout 3 Patch.esm'
     url:
-      - link: 'https://www.nexusmods.com/fallout3/mods/3808/'
-        name: 'Unofficial Fallout 3 Patch'
       - link: 'https://www.nexusmods.com/fallout3/mods/19122/'
         name: 'Updated Unofficial Fallout 3 Patch'
     group: *fixesGroup
@@ -823,34 +821,6 @@ plugins:
     clean:
       - crc: 0xF71755E7
         util: 'FO3Edit v4.0.3'
-  - name: 'Unofficial Fallout 3 Patch - (Operation Anchorage|The Pitt|Broken Steel|Point Lookout|Mothership Zeta)\.esp'
-    url:
-      - link: 'https://www.nexusmods.com/fallout3/mods/3808/'
-        name: 'Unofficial Fallout 3 Patch'
-    group: *fixesGroup
-  - name: 'Unofficial Fallout 3 Patch - Operation Anchorage.esp'
-    tag:
-      - Deflst
-      - Names
-  - name: 'Unofficial Fallout 3 Patch - The Pitt.esp'
-    tag:
-      - Deflst
-      - Names
-  - name: 'Unofficial Fallout 3 Patch - Broken Steel.esp'
-    tag:
-      - Deflst
-      - Names
-      - NoMerge
-  - name: 'Unofficial Fallout 3 Patch - Point Lookout.esp'
-    tag:
-      - Deflst
-      - Invent
-      - Names
-      - Stats
-  - name: 'Unofficial Fallout 3 Patch - Mothership Zeta.esp'
-    tag:
-      - Deflst
-      - Names
 
   - name: 'StreetLights.esm'
     url: [ 'https://www.nexusmods.com/fallout3/mods/8069' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -819,21 +819,6 @@ plugins:
       - 'FO3 Wanderers Edition - Main File.esp'
     req:
       - 'FO3 Wanderers Edition - Main File.esp'
-    tag:
-      - Actors.ACBS
-      - Actors.AIData
-      - Actors.Stats
-      - Deflst
-      - Delev
-      - Destructible
-      - Factions
-      - Graphics
-      - Invent
-      - Names
-      - Relations
-      - Relev
-      - Scripts
-      - Stats
     clean:
       - crc: 0xF404243F
         util: 'FO3Edit v4.0.2e'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -816,9 +816,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/fallout3/mods/19122' ]
     after: [ 'delaypl.esp' ]
     req: [ 'FO3 Wanderers Edition - Main File.esp' ]
-    clean:
-      - crc: 0xF404243F
-        util: 'FO3Edit v4.0.2e'
 
   - name: 'StreetLights.esm'
     url: [ 'https://www.nexusmods.com/fallout3/mods/8069' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -820,11 +820,9 @@ plugins:
       - Relations
       - Relev
       - Stats
-    dirty:
-      - <<: *reqManualFix
-        crc: 0x7AAABC4D
-        util: '[FO3Edit v4.0.2e](https://www.nexusmods.com/fallout3/mods/637)'
-        nav: 2
+    clean:
+      - crc: 0xF71755E7
+        util: 'FO3Edit v4.0.3'
   - name: 'Unofficial Fallout 3 Patch - (Operation Anchorage|The Pitt|Broken Steel|Point Lookout|Mothership Zeta)\.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout3/mods/3808/'


### PR DESCRIPTION
### [UPDATED Unofficial Fallout 3 Patch](https://www.nexusmods.com/fallout3/mods/19122)
Version 3.1.1
- Updated location, requirements, cleaning info and tag suggestions.
- Removed obsolete files and redundant metadata.
- Added tag suggestions to new optional file.