### PR TITLE
Update FOSE Plugin Requirements message

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -898,7 +898,7 @@ globals:
       - lang: da
         text: 'Du har installeret an %1% plugin men %1% blev ikke fundet! Se %1%-downloadsiden: %2%.'
       - lang: de
-        text: 'Sie haben ein %1% plugin installiert, aber %1% wurde nicht gefunden! %1% kann hier heruntergeladen werden: %2%.'
+        text: 'Sie haben ein %1% Plugin installiert, aber %1% wurde nicht gefunden! %1% kann hier heruntergeladen werden: %2%.'
       - lang: es
         text: 'Tienes an %1% plugin instalado pero %1% no se pudo encontrar! Por favor descarga %1%: %2%.'
       - lang: ja


### PR DESCRIPTION
* Capitaliazed "Plugin" was gramatically correct.