### PR TITLE
Remove Brisa - Cooking with FWE and MMM 6

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4924,8 +4924,6 @@ plugins:
       - 'AmyWong - CALIBR 1.3 (FWE 5).esp'
       - 'AmyWong - CALIBR 1.2.esp'
 
-  - name: 'Brisa - Cooking with FWE & MMM 6.esp'
-    inc: [ 'Brisa and FWE - Primary Needs Patch.esp' ]
   - name: 'slaveraider_newlook.esp'
     tag: [ Graphics ]
   - name: 'CharonImproved.esp'


### PR DESCRIPTION
Under #81, Torrello contribution.

Links to mods involved (forgot to include them in the commit message): [Brisa - Cooking with FWE and MMM 6](https://www.nexusmods.com/fallout3/mods/16837/) & [Brisa Almodovar](https://www.nexusmods.com/fallout3/mods/14448/)