### PR TITLE
Correction for cyclic interaction

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8502,9 +8502,7 @@ plugins:
         util: 'FO3Edit v4.0.2e'
   - name: '(TWPC) WD-DIFF3-UUF3P-FWE Patch.esp'
     url: [ 'https://www.nexusmods.com/fallout3/mods/21671/' ]
-    after:
-      - '(TWPC) DIFF3-RI-EVE-MMM-WMK-PRA-F3HMG-F3HF-20CWRE-IMPACT-UUF3P-FWE Patch.esp'
-      - 'Bashed Patch, 0.esp'
+    after: [ 'Bashed Patch, 0.esp' ]
     clean:
       - crc: 0xEE8D886F
         util: 'FO3Edit v4.0.2e'


### PR DESCRIPTION
The user **Lupint** reported on discord a cyclic interaction between `(TWPC) WD-DIFF3-UUF3P-FWE Patch.esp` and `(TWPC) DIFF3-RI-EVE-MMM-WMK-PRA-F3HMG-F3HF-20CWRE-IMPACT-UUF3P-FWE Patch.esp` caused by the masterlist, and they are right. The cyclic interaction was introduced in https://github.com/loot/fallout3/pull/96

[The Wasteland Patch Collection](https://www.nexusmods.com/fallout3/mods/21671/)

According to the file `TWPC_Load_Order.txt` from the above mod pages main file (v1.4), the order should be:
```yaml
(TWPC) WD-DIFF3-UUF3P-FWE Patch.esp
(TWPC) DIFF3-RI-EVE-MMM-WMK-PRA-F3HMG-F3HF-20CWRE-IMPACT-UUF3P-FWE Patch.esp
```
Thanks for the report!