### PR TITLE
Updated Community Ammunition Library

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -826,10 +826,11 @@ plugins:
       - crc: 0xB362BA90
         util: 'FO3Edit v4.0.3h (Hotfix 1)'
 
-  - name: 'CALIBR.esm'
+  - name: 'CALIBR(xMerchant)?\.es[mp]'
     url:
       - link: 'https://www.nexusmods.com/fallout3/mods/3447/'
         name: 'Community Ammunition Library - CALIBR'
+  - name: 'CALIBR.esm'
     group: *fixesGroup
     after: [ 'CRAFT.esm' ]
     clean:
@@ -837,6 +838,11 @@ plugins:
         util: 'FO3Edit v4.0.3'
   - name: 'CALIBRxMerchant.esp'
     group: *fixesGroup
+    dirty:
+      - <<: *quickClean
+        crc: 0xFC210D3A
+        util: '[FO3Edit v4.0.4](https://www.nexusmods.com/fallout3/mods/637)'
+        itm: 4
 
   - name: 'xCALIBR.esm'
     url: [ 'https://www.nexusmods.com/fallout3/mods/11684/' ]


### PR DESCRIPTION
Added cleaning data and a regexp to match to modules. I'm not sure if the regexp is fine as it is though as it felt dirty to simply end with a or that goes nowhere. 

EDIT: Another note is I don't think putting the merchant module in the fixesGroup is appropriate, it fixes nothing and mostly just adds new traders to rivet city and paradise fall