### PR TITLE
Updated Another Interior Mod's clean information

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8710,11 +8710,9 @@ plugins:
         util: 'FO3Edit v4.0.2e'
   - name: 'Another Interior Mod.esp'
     url: [ 'https://www.nexusmods.com/fallout3/mods/22523/' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0x4E80D8A3
-        util: '[FO3Edit v4.0.2e](https://www.nexusmods.com/fallout3/mods/637)'
-        itm: 26
+    clean:
+      - crc: 0x4E80D8A3
+        util: 'FO3Edit v4.0.4'
   - name: 'Armor Repair Kits - FO3.esp'
     url: [ 'https://www.nexusmods.com/fallout3/mods/22541/' ]
     clean:


### PR DESCRIPTION
It's clean according to FO3Edit 4.0.4, seems like the dirty information was added there by mistake. The checksums even match.

`[00:10] Done: Applying Filter, [Pass 1] Processed Records: 25794, [Pass 2] Processed Records: 25673, Remaining unfiltered nodes: 25673, Elapsed Time: 00:05
[Undeleting and Disabling References done]  Processed Records: 25672, Undeleted Records: 0, Elapsed Time: 00:00
[Removing "Identical to Master" records done]  Processed Records: 25672, Removed Records: 0, Elapsed Time: 00:00

LOOT Masterlist Entries

  - name: 'Another Interior Mod.esp'
    clean:
      - crc: 0x4E80D8A3
        util: 'FO3Edit v4.0.4'`