### PR TITLE
Update BnB equipment replacer data

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1543,7 +1543,6 @@ plugins:
       - <<: *useOnlyOneX
         subs: [ 'BNB plugin' ]
         condition: 'many("BnB special armors\.es(m|p)")'
-    msg:
       - <<: *patchUpdateAvailable
         subs: [ '[Illusive Fixes and Merges](https://www.nexusmods.com/fallout3/mods/26618/)' ]
         condition: '(not checksum("BnB special armors.esm", E154BE10) and not checksum("BnB special armors.esp", 4791B69E) and not checksum("meshes\armor\2pac4eva7\bikini armor\croc.nif", BC2CCD69))'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1543,6 +1543,10 @@ plugins:
       - <<: *useOnlyOneX
         subs: [ 'BNB plugin' ]
         condition: 'many("BnB special armors\.es(m|p)")'
+    msg:
+      - <<: *patchUpdateAvailable
+        subs: [ '[Illusive Fixes and Merges](https://www.nexusmods.com/fallout3/mods/26618/)' ]
+        condition: '(not checksum("BnB special armors.esm", E154BE10) and not checksum("BnB special armors.esp", 4791B69E) and not checksum("meshes\armor\2pac4eva7\bikini armor\croc.nif", BC2CCD69))'
     tag:
       - Deflst
       - Delev
@@ -1555,14 +1559,20 @@ plugins:
     dirty:
       - <<: *quickClean
         crc: 0xD0041F38
-        util: '[FO3Edit v4.0.3h (Hotfix 1)](https://www.nexusmods.com/fallout3/mods/637)'
+        util: '[FO3Edit v4.0.4](https://www.nexusmods.com/fallout3/mods/637/)'
         itm: 1468
+    clean:
+      - crc: 0xE6EE3100
+        util: 'FO3Edit v4.0.4'
   - name: 'BnB special armors.esp'
     dirty:
       - <<: *quickClean
         crc: 0xDE5296D8
-        util: '[FO3Edit v4.0.3h (Hotfix 1)](https://www.nexusmods.com/fallout3/mods/637)'
+        util: '[FO3Edit v4.0.4](https://www.nexusmods.com/fallout3/mods/637/)'
         itm: 1468
+    clean:
+      - crc: 0x4BA993AA
+        util: 'FO3Edit v4.0.4'
 
   - name: '(DIM )?CUSTOM RACES( V2)?\.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1558,20 +1558,14 @@ plugins:
     dirty:
       - <<: *quickClean
         crc: 0xD0041F38
-        util: '[FO3Edit v4.0.4](https://www.nexusmods.com/fallout3/mods/637/)'
+        util: 'FNVEdit v4.1.5k'
         itm: 1468
-    clean:
-      - crc: 0xE6EE3100
-        util: 'FO3Edit v4.0.4'
   - name: 'BnB special armors.esp'
     dirty:
       - <<: *quickClean
         crc: 0xDE5296D8
-        util: '[FO3Edit v4.0.4](https://www.nexusmods.com/fallout3/mods/637/)'
+        util: 'FNVEdit v4.1.5k'
         itm: 1468
-    clean:
-      - crc: 0x4BA993AA
-        util: 'FO3Edit v4.0.4'
 
   - name: '(DIM )?CUSTOM RACES( V2)?\.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1558,13 +1558,13 @@ plugins:
     dirty:
       - <<: *quickClean
         crc: 0xD0041F38
-        util: 'FNVEdit v4.1.5k'
+        util: 'FO3Edit v4.1.5k'
         itm: 1468
   - name: 'BnB special armors.esp'
     dirty:
       - <<: *quickClean
         crc: 0xDE5296D8
-        util: 'FNVEdit v4.1.5k'
+        util: 'FO3Edit v4.1.5k'
         itm: 1468
 
   - name: '(DIM )?CUSTOM RACES( V2)?\.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1545,7 +1545,7 @@ plugins:
         condition: 'many("BnB special armors\.es(m|p)")'
       - <<: *patchUpdateAvailable
         subs: [ '[Illusive Fixes and Merges](https://www.nexusmods.com/fallout3/mods/26618/)' ]
-        condition: '(not checksum("BnB special armors.esm", E154BE10) and not checksum("BnB special armors.esp", 4791B69E) and not checksum("meshes\armor\2pac4eva7\bikini armor\croc.nif", BC2CCD69))'
+        condition: 'not checksum("BnB special armors.esm", E154BE10) and not checksum("BnB special armors.esp", 4791B69E) and not checksum("meshes\armor\2pac4eva7\bikini armor\croc.nif", BC2CCD69)'
     tag:
       - Deflst
       - Delev


### PR DESCRIPTION
New cleaning data, mod location (old does not exist), notice to use bugfix patch archive to remove edits that will not be picked up by xEdit QAC.